### PR TITLE
Add section with prototype hardware.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # kitchen
+
+## prototype hardware
+
+This is the current list of components that we recommend prototyping the device with.
+
+
+| Component  | Price  | Purchase From  |
+|------------|--------|----------------|
+| Raspberry Pi 3  | $36  | [Amazon](https://www.amazon.com/Raspberry-Pi-RASP-PI-3-Model-Motherboard/dp/B01CD5VC92)  |
+| USB Webcam  | $40  | [Best Buy](http://www.bestbuy.com/site/logitech-hd-webcam-c525-black/1722057.p), [Amazon](https://www.amazon.com/Logitech-Webcam-Portable-Calling-Autofocus/dp/B004WO8HQ4/ref=sr_1_1?s=pc&ie=UTF8&qid=1467737863&sr=1-1&keywords=Logitech+-+HD+Webcam+C525+-+Black)  |
+| PIR Motion Sensor  | $10  | [Sparkfun](https://www.sparkfun.com/products/13285)  |
+
+In addition you may find it necessary to have a monitor (/w HDMI), mouse and keyboard for working with the Raspberry Pi.


### PR DESCRIPTION
The current hardware is listed in the Google doc, but unless we want to link that here if we ever open source the repo it's hard for people to know how to do DIY this. I also think that having the current version of the hardware alongside the code in a repo makes sense.
